### PR TITLE
Add optional kwarg 'attribute_name' to Field

### DIFF
--- a/flywheel/engine.py
+++ b/flywheel/engine.py
@@ -579,7 +579,10 @@ class Engine(object):
                 kwargs = {}
                 if _raise_on_conflict and name not in constrained_fields:
                     kwargs['expected'] = item.ddb_dump_cached_(name)
-                update = ItemUpdate.put(name, item.ddb_dump_field_(name),
+                value = item.ddb_dump_field_(name)
+                if field is not None:
+                    name = field.attribute_name
+                update = ItemUpdate.put(name, value,
                                         **kwargs)
                 updates.append(update)
 

--- a/flywheel/fields/indexes.py
+++ b/flywheel/fields/indexes.py
@@ -53,12 +53,14 @@ class GlobalIndex(object):
 
     def get_ddb_index(self, fields):
         """ Get the dynamo index class for this GlobalIndex """
-        hash_key = DynamoKey(self.hash_key,
-                             data_type=fields[self.hash_key].ddb_data_type)
+        hash_key = fields[self.hash_key]
+        hash_key = DynamoKey(hash_key.attribute_name,
+                             data_type=hash_key.ddb_data_type)
         range_key = None
         if self.range_key is not None:
-            range_key = DynamoKey(self.range_key,
-                                  data_type=fields[self.range_key].ddb_data_type)
+            range_key = fields[self.range_key]
+            range_key = DynamoKey(range_key.attribute_name,
+                                  data_type=range_key.ddb_data_type)
         index = self.ddb_index(self.name, hash_key, range_key,
                                throughput=self._throughput, **self.kwargs)
         return index

--- a/flywheel/model_meta.py
+++ b/flywheel/model_meta.py
@@ -320,11 +320,11 @@ class ModelMetadata(object):
         if ddb_dump:
             hk = self.hash_key.ddb_dump(hk)
         rk = self.rk(obj, scope)
-        key_dict = {self.hash_key.name: hk}
+        key_dict = {self.hash_key.attribute_name: hk}
         if rk is not None:
             if ddb_dump:
                 rk = self.range_key.ddb_dump(rk)
-            key_dict[self.range_key.name] = rk
+            key_dict[self.range_key.attribute_name] = rk
         return key_dict
 
     @property
@@ -433,11 +433,11 @@ class ModelMetadata(object):
         else:
             table_throughput = self.throughput
 
-        hash_key = DynamoKey(self.hash_key.name,
+        hash_key = DynamoKey(self.hash_key.attribute_name,
                              data_type=self.hash_key.ddb_data_type)
         range_key = None
         if self.range_key is not None:
-            range_key = DynamoKey(self.range_key.name,
+            range_key = DynamoKey(self.range_key.attribute_name,
                                   data_type=self.range_key.ddb_data_type)
         for field in six.itervalues(self.fields):
             if field.index:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -102,6 +102,32 @@ class TestCreateFields(unittest.TestCase):
         Field(data_type=CompressedDict)
         Field(data_type=CompressedDict())
 
+    def test_no_attribute_name(self):
+        """ name and attribute_name default to None """
+        field = Field()
+        assert field.name is None
+        assert field.attribute_name is None
+
+    def test_attribute_name(self):
+        """ attribute_name doesn't override name """
+        field = Field(attribute_name='f')
+        assert field.name is None
+        assert field.attribute_name == 'f'
+
+    def test_name(self):
+        """ attribute_name falls back to name """
+        field = Field()
+        field.name = 'n'
+        assert field.name == 'n'
+        assert field.attribute_name == 'n'
+
+    def test_name_and_attribute_name(self):
+        """ name and attribute_name don't collide """
+        field = Field(attribute_name='f')
+        field.name = 'n'
+        assert field.name == 'n'
+        assert field.attribute_name == 'f'
+
 
 class TestFieldCoerce(unittest.TestCase):
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -54,10 +54,11 @@ class Post(Model):
                       merge=lambda x, y, z: None if z else x + y)
     likes = Field(data_type=int, default=0)
     ts = Field(data_type=float, default=0)
-    deleted = Field(data_type=bool, default=False)
+    deleted = Field(data_type=bool, default=False, attribute_name='del')
     points = Field(data_type=Decimal, default=Decimal('0'))
     about = Field()
     text = Field()
+    data = Field(attribute_name='d')
     tags = Field(data_type=set)
     keywords = Composite('text', 'about', data_type=set,
                          merge=lambda t, a: t.split() + a.split(), coerce=True)
@@ -87,6 +88,14 @@ class TestComposite(DynamoSystemTest):
         self.assertEquals(item['c_range'], w.c_range)
         self.assertEquals(item['c_index'], w.c_index)
         self.assertEquals(item['c_plain'], w.c_plain)
+
+    def test_attribute_name(self):
+        """ Fields with custom attribute_names can save/load """
+        p = Post('a', 'b', 1)
+        p.data = "Text"
+        self.engine.save(p)
+        p_ = self.engine.get(Post, userid='a', id='b')
+        assert p == p_
 
     def test_no_change_composite_hash(self):
         """ Changing the hash key raises an exception """


### PR DESCRIPTION
Implements most of #16 (doesn't handle conflicts)

attribute_name, if defined, will be used as the column name
in AWS DynamoDB, while the field will still be bound to the
model by its name.  For example:

    class MyModel(Model):
        field = Field(attribute_name='f', hash_key=True)

    m = MyModel('uuid')
    print(m.field)  # Prints 'uuid'
    get_engine().save(m, overwrite=True)

The table for this model in AWS DynamoDB would have hash key 'f'.