### PR TITLE
Allow "in" kwarg to be used in query filters

### DIFF
--- a/flywheel/fields/conditions.py
+++ b/flywheel/fields/conditions.py
@@ -39,7 +39,7 @@ class Condition(object):
 
     def query_kwargs(self, model):
         """ Get the kwargs for doing a table query """
-        scan_only = set(['contains', 'ncontains', 'null', 'in', 'ne'])
+        scan_only = set(['contains', 'ncontains', 'null', 'ne'])
         for op, _ in six.itervalues(self.fields):
             if op in scan_only:
                 raise ValueError("Operation '%s' cannot be used in a query!" %


### PR DESCRIPTION
There's an `IN` comparison operator that can in fact be used with table queries. It's mentioned in the API docs at http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html (look for "ComparisonOperator").

The API docs mention some other comparison operators like `BEGINS_WITH`, `BETWEEN`, etc. It would be good to support those too, but I'm not actually familiar with this section of code so I'm not sure if this is the right place for those.

Enjoy your vacation, no hurry on this one either.

(Also submitted on behalf of @skastel.)