### PR TITLE
Fix for boolean values in overflow

### DIFF
--- a/flywheel/fields/__init__.py
+++ b/flywheel/fields/__init__.py
@@ -254,7 +254,9 @@ class Field(object):
     @classmethod
     def ddb_load_overflow(cls, val):
         """ Decode a value of an overflow field """
-        if (isinstance(val, Decimal) or isinstance(val, float) or
+        if isinstance(val, bool):
+            return val
+        elif (isinstance(val, Decimal) or isinstance(val, float) or
                 isinstance(val, six.integer_types)):
             if val % 1 == 0:
                 return int(val)


### PR DESCRIPTION
Boolean values in overflow fields were being converted to decimal due to isinstance(True, int) being True in Python 3.
Check to see if a value is a bool first to handle that special case, then fall back to treating it as a number.